### PR TITLE
Deploy SQL functions in parallel

### DIFF
--- a/skel/bq/Makefile
+++ b/skel/bq/Makefile
@@ -2,6 +2,8 @@
 SED ?= sed
 BQ ?= bq --location=$(BQ_REGION)
 GSUTIL ?= gsutil
+PARALLEL ?= parallel -j10
+TR ?= tr
 
 POST_INTEGRATION_CLEANUP ?= 1
 
@@ -54,9 +56,8 @@ REPLACEMENTS = 	-e 's!@@BQ_PROJECTID@@!$(BQ_PROJECTID)!g' \
 		-e 's!@@SKEL_BQ_LIBRARY@@!$(SKEL_BQ_LIBRARY)!g'
 
 dataset_deploy: check_environment
-	for n in $(wildcard sql/*.sql); do \
-		$(SED) $(REPLACEMENTS) $$n | $(BQ) -q --project_id $(BQ_PROJECTID) query --use_legacy_sql=false || exit; \
-	done
+	echo "$(wildcard sql/*.sql)" | $(TR) " " "\n" | \
+		$(PARALLEL) $(SED) $(REPLACEMENTS) $$n | $(BQ) -q --project_id $(BQ_PROJECTID) query --use_legacy_sql=false
 
 ##################### DEPLOY #####################
 deploy: check_environment


### PR DESCRIPTION
Uploads SQL functions in parallel (10 by default) to speed up the deployment.

References [ch135469](https://app.clubhouse.io/cartoteam/story/135469/parallelize-deployment).