### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   GCLOUD_VERSION: 'latest'
-  NODE_VERSION: '15'
+  NODE_VERSION: '14'
   MAKEFLAGS: '-j2'
 
   BQ_PROJECTID: bqcartoci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ env:
 
   BQ_PROJECTID: bqcartoci
   BQ_BUCKET_PUBLIC: gs://bqcartoci/
-  BQ_DATASET_PREFIX: ${{ github.sha }}_${{ github.run_id }}
+  # Start the dataset prefix with letters to avoid issues with BigQuery parser (it doesn't like datasets starting with numbers: https://issuetracker.google.com/issues/180688209)
+  BQ_DATASET_PREFIX: ci_${{ github.sha }}_${{ github.run_id }}
   POST_INTEGRATION_CLEANUP: 1
 
 jobs:

--- a/skel/bq/test/skel_integration.js
+++ b/skel/bq/test/skel_integration.js
@@ -5,7 +5,7 @@ const BQ_PROJECTID = process.env.BQ_PROJECTID;
 const BQ_DATASET_SKEL = process.env.BQ_DATASET_SKEL;
 
 describe('SKEL integration tests', () => {
-
+    const queryOptions = { 'timeoutMs' : 30000 };
     let client;
     before(async () => {
         if (!BQ_PROJECTID) {
@@ -17,34 +17,22 @@ describe('SKEL integration tests', () => {
         client = new BigQuery({projectId: `${BQ_PROJECTID}`});
     });
 
-    it ('Returns the proper version', async () => {
+    it('Returns the proper version', async () => {
         const query = `SELECT \`${BQ_PROJECTID}\`.\`${BQ_DATASET_SKEL}\`.VERSION() as versioncol;`;
-
-        const options = {
-            query: query
-        };
-
         let rows;
-        await assert.doesNotReject( async () => {
-            const [job] = await client.createQueryJob({ query: query });
-            [rows] = await job.getQueryResults();
+        await assert.doesNotReject(async () => {
+            [rows] = await client.query(query, queryOptions);
         });
         assert.equal(rows.length, 1);
         assert.equal(rows[0].versioncol, 1);
     });
 
 
-    it ('Adds correctly', async () => {
+    it('Adds correctly', async () => {
         const query = `SELECT \`${BQ_PROJECTID}\`.\`${BQ_DATASET_SKEL}\`.EXAMPLE_ADD(5) as addition;`;
-
-        const options = {
-            query: query
-        };
-
         let rows;
-        await assert.doesNotReject( async () => {
-            const [job] = await client.createQueryJob({ query: query });
-            [rows] = await job.getQueryResults();
+        await assert.doesNotReject(async () => {
+            [rows] = await client.query(query, queryOptions);
         });
         assert.equal(rows.length, 1);
         assert.equal(rows[0].addition, 6);


### PR DESCRIPTION
Applies several fixes that appear in multiple PRs and some extra necessary to improve things overall:
* Avoid using datasets starting with numbers (they are fragile in BigQuery, as they work in some situations but not in others).
* Use node 14.
* Use query() instead of createQueryJob(). Query() has only one point of failure, while createQueryJob() and friends might fail in different functions for the exact same query (specially with procedures).