### PR TITLE
S2.keyToId return INT64 instead of UINT64

### DIFF
--- a/s2/library/js/s2geometry.js
+++ b/s2/library/js/s2geometry.js
@@ -1797,7 +1797,7 @@ var S2 =
         bin += '0';
       }
 
-      return Long.fromString(bin, true, 2).toString(10);
+      return Long.fromString(bin, true, 2).toSigned().toString(10);
     };
 
     S2.keyToId = S2.S2Cell.keyToId


### PR DESCRIPTION
S2.keyToId return INT64 instead of UINT64 but with the same binary representation
This is because UINT64 is not a valid type in bigquery.
