### PR TITLE
update function and tests

### DIFF
--- a/quadkey/CHANGELOG.md
+++ b/quadkey/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+* TOPARENT based on entirely SQL implementation.
+
 ## [1.0.0] - 2021-03-31
 
 ### Added

--- a/quadkey/bq/test/parent_integration.js
+++ b/quadkey/bq/test/parent_integration.js
@@ -47,8 +47,19 @@ describe('TOPARENT integration tests', () => {
         assert.equal(rows.length, 0);
     });
 
-    it ('TOPARENT should reject quadints at zoom 0', async () => {
-        let query = `SELECT \`${BQ_PROJECTID}\`.\`${BQ_DATASET_QUADKEY}\`.TOPARENT(0,0)`;
+    it ('TOPARENT should reject quadints with lower level of zoom than the passed resolution', async () => {
+        let query = `-- Passing zoom 3 quadint
+        SELECT \`${BQ_PROJECTID}\`.\`${BQ_DATASET_QUADKEY}\`.TOPARENT(291,4)`;
+        await assert.rejects( async () => {
+            [rows] = await client.query(query, queryOptions);
+        });
+        query = `-- Passing zoom 10 quadint
+        SELECT \`${BQ_PROJECTID}\`.\`${BQ_DATASET_QUADKEY}\`.TOPARENT(3280010,11)`;
+        await assert.rejects( async () => {
+            [rows] = await client.query(query, queryOptions);
+        });
+        query = `-- Passing zoom 14 quadint
+        SELECT \`${BQ_PROJECTID}\`.\`${BQ_DATASET_QUADKEY}\`.TOPARENT(52432014,15)`;
         await assert.rejects( async () => {
             [rows] = await client.query(query, queryOptions);
         });


### PR DESCRIPTION
I'm updating toparent to its sql version which is way faster.
Could have done more checks but this should be enough for covering the major issues without decreasing performance too much. The main difference with the previous is that this version accepts getting a quadint with the same resolution that the sent one and it would return the same value.

For instance:
-- bqcarto.quadkey.QUADINT_FROMZXY(3,1,1) -> 291
bqcarto.quadkey.TOPARENT(291, 3) -> 291

Closes #63 


The test will fail until the next PR is merged:
https://github.com/CartoDB/carto-spatial-extension/pull/65