### PR TITLE
Added ST_TILEENVELOPE to "constructors" module

### DIFF
--- a/constructors/CHANGELOG.md
+++ b/constructors/CHANGELOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Initial implementation of the module.
 * Add ST_MAKEENVELOPE function
+* Add ST_TILEENVELOPE function

--- a/constructors/bq/Makefile
+++ b/constructors/bq/Makefile
@@ -27,6 +27,9 @@ endif
 ifndef BQ_BUCKET_PUBLIC
 	$(error BQ_BUCKET_PUBLIC is undefined)
 endif
+ifndef BQ_DATASET_QUADKEY
+	$(error BQ_DATASET_QUADKEY is undefined)
+endif
 
 all check:
 
@@ -50,6 +53,7 @@ dataset_remove: check_environment
 
 REPLACEMENTS = -e 's!@@BQ_PROJECTID@@!$(BQ_PROJECTID)!g' \
 		-e 's!@@BQ_DATASET_CONSTRUCTORS@@!$(BQ_DATASET_CONSTRUCTORS)!g' \
+		-e 's!@@BQ_DATASET_QUADKEY@@!$(BQ_DATASET_QUADKEY)!g' \
 		-e 's!@@CONSTRUCTORS_BQ_LIBRARY@@!$(CONSTRUCTORS_BQ_LIBRARY)!g'
 
 dataset_deploy: check_environment
@@ -58,7 +62,9 @@ dataset_deploy: check_environment
 	done
 
 ##################### DEPLOY #####################
+BQ_QUADKEY_PATH = ../../quadkey/bq
 deploy: check_environment
+	$(BQ) --project_id $(BQ_PROJECTID) show $(BQ_DATASET_QUADKEY) 2>/dev/null 1>/dev/null || $(MAKE) -C $(BQ_QUADKEY_PATH) $@
 	$(MAKE) storage_upload
 	$(MAKE) dataset_create
 	$(MAKE) dataset_deploy
@@ -72,5 +78,7 @@ check-integration: check_environment
 # Note, on failure we add a explicit sleep to wait until all resources are unused before retrying
 integration_cleanup: check_environment
 ifeq ($(POST_INTEGRATION_CLEANUP), 1)
+	$(MAKE) storage_remove
 	$(MAKE) dataset_remove || ((sleep 5 && $(MAKE) dataset_remove) || exit 1)
+	$(MAKE) -C $(BQ_QUADKEY_PATH) $@
 endif

--- a/constructors/bq/doc/REFERENCE.md
+++ b/constructors/bq/doc/REFERENCE.md
@@ -7,7 +7,7 @@ This module contains functions that create geographies from coordinates or alrea
 ### ST_MAKEENVELOPE
 
 {{% bannerNote type="code" %}}
-transformation.ST_MAKEENVELOPE(xmin, ymin, xma, ymax)
+constructors.ST_MAKEENVELOPE(xmin, ymin, xma, ymax)
 {{%/ bannerNote %}}
 
 **Description**
@@ -28,6 +28,30 @@ Creates a rectangular Polygon from the minimum and maximum values for X and Y.
 ``` sql
 SELECT bqcarto.constructors.ST_MAKEENVELOPE(0,0,1,1);
 -- POLYGON((1 0, 1 1, 0 1, 0 0, 1 0)) 
+```
+
+### ST_TILEENVELOPE
+
+{{% bannerNote type="code" %}}
+constructors.ST_TILEENVELOPE(zoomLevel, xTile, yTile)
+{{%/ bannerNote %}}
+
+**Description**
+Returns the boundary polygon of a tile given its zoom level and its X and Y indices.
+
+* `zoomLevel`: `INT64` zoom level of the tile.
+* `xTile`: `INT64` X index of the tile.
+* `yTile`: `INT64` Y index of the tile.
+
+**Return type**
+
+`GEOGRAPHY`
+
+**Example**
+
+``` sql
+SELECT bqcarto.constructors.ST_TILEENVELOPE(10,384,368);
+-- POLYGON((-45 45.089035564831, -45 44.840290651398, -44.82421875 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -44.82421875 45.089035564831, -45 45.089035564831))
 ```
 
 ### VERSION

--- a/constructors/bq/sql/ST_TILEENVELOPE.sql
+++ b/constructors/bq/sql/ST_TILEENVELOPE.sql
@@ -1,0 +1,13 @@
+-----------------------------------------------------------------------
+--
+-- Copyright (C) 2021 CARTO
+--
+-----------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION `@@BQ_PROJECTID@@.@@BQ_DATASET_CONSTRUCTORS@@.ST_TILEENVELOPE`
+    (zoomLevel INT64, xTile INT64, yTile INT64)
+RETURNS GEOGRAPHY
+OPTIONS (description="Returns the boundary polygon of a tile given its zoom level and its X and Y indices.")
+AS (
+    `@@BQ_PROJECTID@@.@@BQ_DATASET_QUADKEY@@.ST_BOUNDARY`(`@@BQ_PROJECTID@@.@@BQ_DATASET_QUADKEY@@.QUADINT_FROMZXY`(zoomLevel,xTile,yTile))
+);

--- a/constructors/bq/test/tileenvelope_integration.js
+++ b/constructors/bq/test/tileenvelope_integration.js
@@ -1,0 +1,41 @@
+const assert = require('assert').strict;
+const {BigQuery} = require('@google-cloud/bigquery');
+
+const BQ_PROJECTID = process.env.BQ_PROJECTID;
+const BQ_DATASET_CONSTRUCTORS = process.env.BQ_DATASET_CONSTRUCTORS;
+
+describe('TILEENVELOPE integration tests', () => {
+    const queryOptions = { 'timeoutMs' : 30000 };
+    let client;
+    before(async () => {
+        if (!BQ_PROJECTID) {
+            throw "Missing BQ_PROJECTID env variable";
+        }
+        if (!BQ_DATASET_CONSTRUCTORS) {
+            throw "Missing BQ_DATASET_CONSTRUCTORS env variable";
+        }
+        client = new BigQuery({projectId: `${BQ_PROJECTID}`});
+    });
+
+    it ('TILEENVELOPE should work', async () => {
+        let query = `SELECT \`${BQ_PROJECTID}\`.\`${BQ_DATASET_CONSTRUCTORS}\`.ST_TILEENVELOPE(10,384,368) as geog1,
+        \`${BQ_PROJECTID}\`.\`${BQ_DATASET_CONSTRUCTORS}\`.ST_TILEENVELOPE(18,98304,94299) as geog2,
+        \`${BQ_PROJECTID}\`.\`${BQ_DATASET_CONSTRUCTORS}\`.ST_TILEENVELOPE(25,12582912,12070369) as geog3`;
+        await assert.doesNotReject( async () => {
+            [rows] = await client.query(query, queryOptions);
+        });
+        assert.equal(rows.length, 1);
+        assert.equal(rows[0]['geog1']['value'],'POLYGON((-45 45.089035564831, -45 44.840290651398, -44.82421875 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -44.82421875 45.089035564831, -45 45.089035564831))');
+        assert.equal(rows[0]['geog2']['value'],'POLYGON((-45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813, -44.9986267089844 45.0007380782907, -45 45.0007380782907))');
+        assert.equal(rows[0]['geog3']['value'],'POLYGON((-45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367, -44.9999892711639 45.0000021990696, -45 45.0000021990696))');
+    });
+
+    it ('TILEENVELOPE should fail if any NULL argument', async () => {
+        let rows;
+        let query = `SELECT \`${BQ_PROJECTID}\`.\`${BQ_DATASET_CONSTRUCTORS}\`.ST_TILEENVELOPE(10,384,null);`;
+        await assert.rejects( async () => {
+            [rows] = await client.query(query, queryOptions);
+        });
+    });
+
+}); /* MAKEENVELOPE integration tests */

--- a/tools/setool/lib/create-module/generator.js
+++ b/tools/setool/lib/create-module/generator.js
@@ -460,7 +460,8 @@ function createBQSQLVersion (name, library) {
 
 CREATE OR REPLACE FUNCTION \`@@BQ_PROJECTID@@.@@BQ_DATASET_${uname}@@.VERSION\`()
     RETURNS STRING
-    DETERMINISTIC${islib(`LANGUAGE js
+    DETERMINISTIC${islib(`
+    LANGUAGE js
     OPTIONS (library=["@@${uname}_BQ_LIBRARY@@"])`)}
 AS """
     return ${library ? `${lname}Version()` : `'1.0.0'`};


### PR DESCRIPTION
The original PostGIS function (https://postgis.net/docs/ST_TileEnvelope.html) also includes an extra `margin` parameter to grow a tile by the given percentage. As we stated in Slack, the current implementation uses just the (x,y,z) index to extract the polygon but in case the `margin`parameter is further required, this implementation is not valid and we must go with a previous step for extracting the bounding box. We can use something like this:

```sql
    SELECT `@@BQ_PROJECTID@@.@@BQ_DATASET_CONSTRUCTORS@@.ST_MAKEENVELOPE`(
        bounds[OFFSET(0)],
        bounds[OFFSET(1)],
        bounds[OFFSET(2)],
        bounds[OFFSET(3)]
    )
    FROM (
        SELECT `@@BQ_PROJECTID@@.@@BQ_DATASET_QUADKEY@@.BBOX`(
            `@@BQ_PROJECTID@@.@@BQ_DATASET_QUADKEY@@.QUADINT_FROMZXY`(zoomLevel,xTile,yTile)) AS bounds
    )
```

The problem is the `ST_MAKEPOLYGON` used in our `ST_MAKEENVELOPE` has some issues with dealing with lower zoom levels, splitting the resulting polygon in a weird fashion, e.g. giving this result for the (0,0,0) tile:

`GEOMETRYCOLLECTION(POLYGON((0 0, 120 0, -120 0, 0 0)), POLYGON((0 0, -120 0, 120 0, 0 0)))`

In conclusion, I would keep the signature as it is, just tanking the tile index.