### PR TITLE
Allow sharing with multiple shares in Snowflake

### DIFF
--- a/common/snowflake/Makefile
+++ b/common/snowflake/Makefile
@@ -6,7 +6,9 @@ SNOWSQL ?= snowsql
 
 SF_SCHEMA = $(SF_SCHEMA_PREFIX)$(MODULE)
 SF_PREFIX = $(SF_DATABASE).$(SF_SCHEMA_PREFIX)
-SF_SHARE = $(SF_SCHEMA_PREFIX)$(SF_SHARE_PREFIX)SPATIAL_EXTENSIONS
+SF_SHARES = \
+	$(SF_SCHEMA_PREFIX)$(SF_SHARE_PREFIX)SPATIAL_EXTENSIONS \
+	$(SF_SCHEMA_PREFIX)$(SF_SHARE_PREFIX)ADVANCED_SPATIAL_EXTENSIONS 
 
 SF_LIBRARY = ./dist/index.js
 
@@ -21,7 +23,7 @@ NODE_MODULES_DEPS = $(COMMON_DIR)/node_modules
 
 REPLACEMENTS_LIBS += $(foreach f,$(notdir $(basename $(wildcard dist/*.js))),-e '/@@SF_LIBRARY_$(shell echo $f | tr a-z A-Z)@@/ r ./dist/$f.js' -e 's!@@SF_LIBRARY_$(shell echo $f | tr a-z A-Z)@@!!g' )
 
-REPLACEMENTS = 	-e 's!@@SF_PREFIX@@!$(SF_PREFIX)!g' -e 's!@@SF_DATABASE@@!$(SF_DATABASE)!g' -e 's!@@SF_SCHEMA@@!$(SF_SCHEMA)!g' -e 's!@@SF_SHARE@@!$(SF_SHARE)!g' -e '/@@SF_LIBRARY_CONTENT@@/ r $(SF_LIBRARY)' -e 's!@@SF_LIBRARY_CONTENT@@!!g'
+REPLACEMENTS = 	-e 's!@@SF_PREFIX@@!$(SF_PREFIX)!g' -e 's!@@SF_DATABASE@@!$(SF_DATABASE)!g' -e 's!@@SF_SCHEMA@@!$(SF_SCHEMA)!g' -e '/@@SF_LIBRARY_CONTENT@@/ r $(SF_LIBRARY)' -e 's!@@SF_LIBRARY_CONTENT@@!!g'
 REPLACEMENTS += REPLACEMENTS_LIBS
 
 REPLACEMENTS_PKG = -e 's!@@SF_PREFIX@@!!g' -e '/@@SF_LIBRARY_CONTENT@@/ r $(SF_LIBRARY)' -e 's!@@SF_LIBRARY_CONTENT@@!!g'
@@ -108,12 +110,18 @@ schema-deploy:
 
 share-create:
 ifeq ($(SF_SHARE_ENABLED), 1)
-	$(SED) $(REPLACEMENTS) $(SHARE_CREATE_FILE) | $(SNOWSQL) -q "$(xargs)" 
+	for f in ${SF_SHARES}; do \
+		SHARE_QUERY=$$($(SED) $(REPLACEMENTS) $(SHARE_CREATE_FILE) | $(SED) -e 's!@@SF_SHARE@@!'$$f'!g'); \
+		$(SNOWSQL) -q "$$SHARE_QUERY"; \
+	done
 endif
 
 share-remove:
 ifeq ($(SF_SHARE_ENABLED), 1)
-	$(SED) $(REPLACEMENTS) $(SHARE_REMOVE_FILE) | $(SNOWSQL) -q "$(xargs)" 
+	for f in ${SF_SHARES}; do \
+		SHARE_QUERY=$$($(SED) $(REPLACEMENTS) $(SHARE_REMOVE_FILE) | $(SED) -e 's!@@SF_SHARE@@!'$$f'!g'); \
+		$(SNOWSQL) -q "$$SHARE_QUERY"; \
+	done
 endif
 
 serialize-module:

--- a/common/snowflake/Makefile
+++ b/common/snowflake/Makefile
@@ -24,10 +24,10 @@ NODE_MODULES_DEPS = $(COMMON_DIR)/node_modules
 REPLACEMENTS_LIBS += $(foreach f,$(notdir $(basename $(wildcard dist/*.js))),-e '/@@SF_LIBRARY_$(shell echo $f | tr a-z A-Z)@@/ r ./dist/$f.js' -e 's!@@SF_LIBRARY_$(shell echo $f | tr a-z A-Z)@@!!g' )
 
 REPLACEMENTS = 	-e 's!@@SF_PREFIX@@!$(SF_PREFIX)!g' -e 's!@@SF_DATABASE@@!$(SF_DATABASE)!g' -e 's!@@SF_SCHEMA@@!$(SF_SCHEMA)!g' -e '/@@SF_LIBRARY_CONTENT@@/ r $(SF_LIBRARY)' -e 's!@@SF_LIBRARY_CONTENT@@!!g'
-REPLACEMENTS += REPLACEMENTS_LIBS
+REPLACEMENTS += $(REPLACEMENTS_LIBS)
 
 REPLACEMENTS_PKG = -e 's!@@SF_PREFIX@@!!g' -e '/@@SF_LIBRARY_CONTENT@@/ r $(SF_LIBRARY)' -e 's!@@SF_LIBRARY_CONTENT@@!!g'
-REPLACEMENTS_PKG += REPLACEMENTS_LIBS
+REPLACEMENTS_PKG += $(REPLACEMENTS_LIBS)
 
 .SILENT:
 

--- a/modules/accessors/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/accessors/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/modules/constructors/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/constructors/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/modules/h3/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/h3/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/modules/measurements/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/measurements/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/modules/placekey/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/placekey/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/modules/processing/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/processing/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/modules/quadkey/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/quadkey/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/modules/s2/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/s2/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/modules/transformations/snowflake/sql/_SHARE_REMOVE.sql
+++ b/modules/transformations/snowflake/sql/_SHARE_REMOVE.sql
@@ -2,4 +2,5 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;

--- a/tools/setool/lib/create-module/generator.js
+++ b/tools/setool/lib/create-module/generator.js
@@ -145,6 +145,7 @@ grant usage on function @@SF_PREFIX@@${name}.VERSION() to share @@SF_SHARE@@;`;
 
     content = `${header}
 
+USE role ACCOUNTADMIN;
 DROP SHARE @@SF_SHARE@@;`;
 
     createFile([root, 'modules', name, cloud, 'sql', '_SHARE_REMOVE.sql'], content);


### PR DESCRIPTION
- We were losing links between functions and shares on each deployment. We are using the `ADVANCED_SPATIAL_EXTENSION` share in the marketplace and each time we deploy core very likely the links to that share were broken. Now each time we deploy core it will also add the core functions to the `ADVANCED_SPATIAL_EXTENSION` share so the link shouldn't be lost anymore. Would be awesome as well to request the SF team for a `COPY GRANTS` option.

- I use this PR also to add `USE ROLE ACCOUNTADMIN` in the `share-remove` since it should be crashing.