### PR TITLE
Fix Quadint ST_BOUNDARY

### DIFF
--- a/modules/quadkey/bigquery/sql/BBOX.sql
+++ b/modules/quadkey/bigquery/sql/BBOX.sql
@@ -48,13 +48,15 @@ AS (
 
 CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_N`
 (quadint INT64)
-RETURNS FLOAT64 AS (
+RETURNS FLOAT64
+AS (
     `@@BQ_PREFIX@@quadkey.__TILE2LAT`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).y, `@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
 );
 
 CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_S`
 (quadint INT64)
-RETURNS FLOAT64 AS (
+RETURNS FLOAT64
+AS (
     `@@BQ_PREFIX@@quadkey.__TILE2LAT`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).y+1, `@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
 );
 

--- a/modules/quadkey/bigquery/sql/BBOX.sql
+++ b/modules/quadkey/bigquery/sql/BBOX.sql
@@ -2,54 +2,70 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__N`(y FLOAT64,z FLOAT64)
-RETURNS FLOAT64 AS (
-ACOS(-1)*(1-2*y/POW(2,z))
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__N`
+(y FLOAT64,z FLOAT64)
+RETURNS FLOAT64
+AS (
+    ACOS(-1)*(1-2*y/POW(2,z))
 );
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__TILE2LAT`(y FLOAT64,z FLOAT64)
-RETURNS FLOAT64 AS (
-COALESCE(
-      180/ACOS(-1)*ATAN(0.5*(
-      EXP(`@@BQ_PREFIX@@quadkey.__N`(y,z))
-      -EXP(-`@@BQ_PREFIX@@quadkey.__N`(y,z))
-      )),
-ERROR('NULL argument passed to UDF')
-)
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__TILE2LAT`
+(y FLOAT64,z FLOAT64)
+RETURNS FLOAT64
+AS (
+    COALESCE(
+        180/ACOS(-1)*ATAN(0.5*(
+        EXP(`@@BQ_PREFIX@@quadkey.__N`(y,z))
+        -EXP(-`@@BQ_PREFIX@@quadkey.__N`(y,z))
+        )),
+    ERROR('NULL argument passed to UDF')
+    )
 );
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__TILE2LON`(x FLOAT64, z FLOAT64)
-RETURNS FLOAT64 AS (
-COALESCE(
-(x)/POW(2,z)*360-180,
-ERROR('NULL argument passed to UDF')
-)
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__TILE2LON`
+(x FLOAT64, z FLOAT64)
+RETURNS FLOAT64
+AS (
+    COALESCE(
+    (x)/POW(2,z)*360-180,
+    ERROR('NULL argument passed to UDF')
+    )
 );
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint INT64)
-RETURNS FLOAT64 AS (
-`@@BQ_PREFIX@@quadkey.__TILE2LON`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).x  ,`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_E`
+(quadint INT64)
+RETURNS FLOAT64
+AS (
+    `@@BQ_PREFIX@@quadkey.__TILE2LON`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).x + 1, `@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
 );
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX__N`(quadint INT64)
-RETURNS FLOAT64 AS (
-`@@BQ_PREFIX@@quadkey.__TILE2LAT`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).y  ,`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_W`
+(quadint INT64)
+RETURNS FLOAT64
+AS (
+    `@@BQ_PREFIX@@quadkey.__TILE2LON`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).x, `@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
 );
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint INT64)
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_N`
+(quadint INT64)
 RETURNS FLOAT64 AS (
-`@@BQ_PREFIX@@quadkey.__TILE2LON`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).x+1,`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
+    `@@BQ_PREFIX@@quadkey.__TILE2LAT`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).y, `@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
 );
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint INT64)
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.__BBOX_S`
+(quadint INT64)
 RETURNS FLOAT64 AS (
-`@@BQ_PREFIX@@quadkey.__TILE2LAT`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).y+1,`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
+    `@@BQ_PREFIX@@quadkey.__TILE2LAT`(`@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).y+1, `@@BQ_PREFIX@@quadkey.ZXY_FROMQUADINT`(quadint).z)
 );
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.BBOX`(quadint INT64)
-RETURNS ARRAY<FLOAT64> AS ([
-`@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
-`@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
-`@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint),
-`@@BQ_PREFIX@@quadkey.__BBOX__N`(quadint)
-]);
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.BBOX`
+(quadint INT64)
+RETURNS ARRAY<FLOAT64>
+AS (
+    [
+        `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
+        `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint),
+        `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
+        `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint)
+    ]
+);

--- a/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
+++ b/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
@@ -5,30 +5,11 @@
 CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.ST_BOUNDARY`(quadint INT64)
 RETURNS GEOGRAPHY AS (
 COALESCE(
-ST_MAKEPOLYGON(
-ST_MAKELINE([
-ST_GEOGPOINT(
-`@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
-`@@BQ_PREFIX@@quadkey.__BBOX__N`(quadint)
-),
-ST_GEOGPOINT(
-`@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
-`@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint)
-),
-ST_GEOGPOINT(
-`@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint),
-`@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint)
-),
-ST_GEOGPOINT(
-`@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint),
-`@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint)
-),
-ST_GEOGPOINT(
-`@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
-`@@BQ_PREFIX@@quadkey.__BBOX__N`(quadint)
-)
-])
-),
-ERROR('NULL argument passed to UDF')
-)
+        `@@BQ_PREFIX@@constructors.ST_MAKEENVELOPE`(
+        `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
+        `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint),
+        `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
+        `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint)),
+        ERROR('NULL argument passed to UDF')
+    )
 );

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -8,10 +8,10 @@ test('ST_BOUNDARY should work', async () => {
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12960460429066265) as geog3`;
     
     const rows = await runQuery(query);
-    expect(rows.length).toEqual(1);  
-    expect(JSON.stringify(rows[0].geog1.value)).toEqual('"POLYGON((-45 45.089035564831, -45 44.840290651398, -44.6484375 44.840290651398, -45 45.089035564831))"');
-    expect(JSON.stringify(rows[0].geog2.value)).toEqual('"POLYGON((-45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813, -45 45.0007380782907))"');
-    expect(JSON.stringify(rows[0].geog3.value)).toEqual('"POLYGON((-45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367, -45 45.0000021990696))"');
+    expect(rows.length).toEqual(1);
+    expect(JSON.stringify(rows[0].geog1.value)).toEqual('"POLYGON((-44.6484375 44.840290651398, -44.6484375 45.089035564831, -45 45.089035564831, -45 44.840290651398, -44.6484375 44.840290651398))"');
+    expect(JSON.stringify(rows[0].geog2.value)).toEqual('"POLYGON((-44.9986267089844 44.9997670191813, -44.9986267089844 45.0007380782907, -45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813))"');
+    expect(JSON.stringify(rows[0].geog3.value)).toEqual('"POLYGON((-44.9999892711639 44.9999946126367, -44.9999892711639 45.0000021990696, -45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367))"'); 
 });
 
 test('ST_BOUNDARY should fail with NULL argument', async () => {


### PR DESCRIPTION
- Fix issues with __BBOX components returning wrong values.
- Format a bit the functions.
- Reorder the values of BBOX to [xmin, ymin, xmax, ymax]