### PR TITLE
Use ST_MAKEPOLYGON ST_MAKELINE ST_GEOGPOINT instead of ST_GeogFromText

### DIFF
--- a/modules/constructors/bigquery/sql/ST_MAKEENVELOPE.sql
+++ b/modules/constructors/bigquery/sql/ST_MAKEENVELOPE.sql
@@ -7,5 +7,13 @@ CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@constructors.ST_MAKEENVELOPE`
 RETURNS GEOGRAPHY
 OPTIONS (description="Creates a rectangular Polygon from the minimum and maximum values for X and Y")
 AS (
-    ST_GeogFromText(CONCAT('POLYGON((', xmin, ' ', ymin, ',', xmin, ' ', ymax, ',', xmax, ' ', ymax, ',', xmax, ' ', ymin, ',', xmin, ' ', ymin, '))'))
+    ST_MAKEPOLYGON(
+        ST_MAKELINE([
+            ST_GEOGPOINT(xmin, ymin),
+            ST_GEOGPOINT(xmin, ymax),
+            ST_GEOGPOINT(xmax, ymax),
+            ST_GEOGPOINT(xmax, ymin),
+            ST_GEOGPOINT(xmin, ymin)
+            ])
+        )
 );

--- a/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
+++ b/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
@@ -2,23 +2,29 @@
 -- Copyright (C) 2021 CARTO
 ----------------------------
 
-CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey._MAKEENVELOPE`
-(xmin FLOAT64, ymin FLOAT64, xmax FLOAT64, ymax FLOAT64)
-RETURNS GEOGRAPHY
-AS (
-    ST_GeogFromText(CONCAT('POLYGON((', xmin, ' ', ymin, ',', xmin, ' ', ymax, ',', xmax, ' ', ymax, ',', xmax, ' ', ymin, ',', xmin, ' ', ymin, '))'))
-);
-
 CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.ST_BOUNDARY`(quadint INT64)
 RETURNS GEOGRAPHY
 AS (
     COALESCE(
-        `@@BQ_PREFIX@@quadkey._MAKEENVELOPE`(
-            `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
-            `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint),
-            `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
-            `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint)
-        ),
+        ST_MAKEPOLYGON(
+            ST_MAKELINE([
+                ST_GEOGPOINT(
+                    `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
+                    `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint)),
+                ST_GEOGPOINT(
+                    `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
+                    `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint)),
+                ST_GEOGPOINT(
+                    `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
+                    `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint)),
+                ST_GEOGPOINT(
+                    `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
+                    `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint)),
+                ST_GEOGPOINT(
+                    `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
+                    `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint))
+                ])
+            ),
         ERROR('NULL argument passed to UDF')
     )
 );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7817985/127838841-395d1db2-e644-4c12-9ab5-89efa6984b27.png)
![image](https://user-images.githubusercontent.com/7817985/127838857-49028ecd-db98-4cd9-ad50-46aa837b3c19.png)
 ST_MAKEPOLYGON + ST_MAKELINE + ST_GEOGPOINT reduce computing time by 20% and workers time by 50% in comparison to WKT parsing