### PR TITLE
Granting bq permissions to spatial extension groups per environment

### DIFF
--- a/common/bigquery/set_module_permissions_group.sh
+++ b/common/bigquery/set_module_permissions_group.sh
@@ -7,17 +7,34 @@
 # * BQ_PERMISSIONS_ROLE_NAME
 # * BQ_PERMISSIONS_TARGET_DATASET
 
-BQ_PERMISSIONS_ROLE=projects/$BQ_PROJECT/roles/$BQ_PERMISSIONS_ROLE_NAME
+#############################################################################################
+# We do have spatial extension groups for several environments:
+# - spatial_extension_users_la@cartodb.com
+# - spatial_extension_users_la-stag@cartodb.com
+# - spatial_extension_users_la-dev@cartodb.com
+#
+# NOTE: We add this logic in the script, to reduce complexity in the github actions workflow
+#############################################################################################
+BQ_PERMISSIONS_GROUP_ENV="-prod -stag -dev"
 
-echo "Setting $BQ_PERMISSIONS_GROUP permissions to $BQ_PROJECT:$BQ_PERMISSIONS_TARGET_DATASET"
+
+BQ_PERMISSIONS_ROLE=projects/$BQ_PROJECT/roles/$BQ_PERMISSIONS_ROLE_NAME
 
 PERMISSIONS_TEMPFILE_OLD=$(mktemp -u /tmp/old_module_permissions_XXXXXXXXXXXXXXXXX)
 PERMISSIONS_TEMPFILE_NEW=$(mktemp -u /tmp/new_module_permissions_XXXXXXXXXXXXXXXXX)
 
-bq show --format=prettyjson ${BQ_PROJECT}:${BQ_PERMISSIONS_TARGET_DATASET} > ${PERMISSIONS_TEMPFILE_OLD}
-jq --argjson access '[{"groupByEmail":"'"$BQ_PERMISSIONS_GROUP"'","role":"'"$BQ_PERMISSIONS_ROLE"'"}]' \
-   '.access += $access' ${PERMISSIONS_TEMPFILE_OLD} > ${PERMISSIONS_TEMPFILE_NEW}
-bq update --source ${PERMISSIONS_TEMPFILE_NEW} ${BQ_PROJECT}:${BQ_PERMISSIONS_TARGET_DATASET}
+# Iterate over each set of group + environment
+for _ENV in ${BQ_PERMISSIONS_GROUP_ENV}; do
+  BQ_PERMISSIONS_GROUP_PER_ENV=$(echo ${BQ_PERMISSIONS_GROUP} | \
+    awk -v _env=${_ENV} -F"@" ' { new_group=$1_env"@"$2; gsub("-prod","",new_group); print new_group } ')
+
+  echo "Setting $BQ_PERMISSIONS_GROUP_PER_ENV permissions to $BQ_PROJECT:$BQ_PERMISSIONS_TARGET_DATASET"
+
+  bq show --format=prettyjson ${BQ_PROJECT}:${BQ_PERMISSIONS_TARGET_DATASET} > ${PERMISSIONS_TEMPFILE_OLD}
+  jq --argjson access '[{"groupByEmail":"'"$BQ_PERMISSIONS_GROUP_PER_ENV"'","role":"'"$BQ_PERMISSIONS_ROLE"'"}]' \
+     '.access += $access' ${PERMISSIONS_TEMPFILE_OLD} > ${PERMISSIONS_TEMPFILE_NEW}
+  bq update --source ${PERMISSIONS_TEMPFILE_NEW} ${BQ_PROJECT}:${BQ_PERMISSIONS_TARGET_DATASET}
+done
 
 rm -f ${PERMISSIONS_TEMPFILE_OLD}*
 rm -f ${PERMISSIONS_TEMPFILE_NEW}*


### PR DESCRIPTION
https://app.clubhouse.io/cartoteam/story/172674/add-new-accounts-to-the-spatial-extension-google-groups-from-the-backend

## Context
For the integration of `carto3` and `spatial extension`, we have created new **google groups** per environment (https://github.com/CartoDB/terraform-it-general/pull/27)

```
  # Production
  "spatialextension_users_st@cartodb.com" : "Spatial extension group for starter (st) price plan",
  "spatialextension_users_sm@cartodb.com" : "Spatial extension group for small (sm) price plan",
  "spatialextension_users_me@cartodb.com" : "Spatial extension group for medium (me) price plan",
  "spatialextension_users_la@cartodb.com" : "Spatial extension group for large (la) price plan",
  "spatialextension_users_un@cartodb.com" : "Spatial extension group for unlimited (un) price plan"
  # Staging
  "spatialextension_users_st-stag@cartodb.com" : "Spatial extension group for starter (st) price plan",
  "spatialextension_users_sm-stag@cartodb.com" : "Spatial extension group for small (sm) price plan",
  "spatialextension_users_me-stag@cartodb.com" : "Spatial extension group for medium (me) price plan",
  "spatialextension_users_la-stag@cartodb.com" : "Spatial extension group for large (la) price plan",
  "spatialextension_users_un-stag@cartodb.com" : "Spatial extension group for unlimited (un) price plan"
  # Dev (dedicateds and local env)
  "spatialextension_users_st-dev@cartodb.com" : "Spatial extension group for starter (st) price plan",
  "spatialextension_users_sm-dev@cartodb.com" : "Spatial extension group for small (sm) price plan",
  "spatialextension_users_me-dev@cartodb.com" : "Spatial extension group for medium (me) price plan",
  "spatialextension_users_la-dev@cartodb.com" : "Spatial extension group for large (la) price plan",
  "spatialextension_users_un-dev@cartodb.com" : "Spatial extension group for unlimited (un) price plan"
```

So, we need to grant at **bigquery level** the same permissions for the new `-stag` and `-dev` groups. I've been taking a look to the [github workflow](https://github.com/CartoDB/carto-advanced-spatial-extension/blob/master/.github/workflows/deploy-production.yml#L27-L76), but after a while, i decided to add the **per environment** logic into the [set_module_permissions_group.sh script](https://github.com/CartoDB/carto-advanced-spatial-extension/blob/master/common/bigquery/set_module_permissions_group.sh), otherwise the workflow readability would be bad.

## Testing the script locally

```
$ BQ_PROJECT=test_project BQ_PERMISSIONS_GROUP=spatial_extension_users_me@cartodb.com BQ_PERMISSIONS_ROLE_NAME=test_role BQ_PERMISSIONS_TARGET_DATASET=test_db bash set_module_permissions_group.sh
Setting spatial_extension_users_me@cartodb.com permissions to test_project:test_db
Setting spatial_extension_users_me-stag@cartodb.com permissions to test_project:test_db
Setting spatial_extension_users_me-dev@cartodb.com permissions to test_project:test_db
```

Would you please take a look @Jesus89 @vdelacruzb (i might be missing something else).

Thanks a lot.