### PR TITLE
Perf improvement in st asquadint polyfill

### DIFF
--- a/modules/quadkey/bigquery/CHANGELOG.md
+++ b/modules/quadkey/bigquery/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2021-09-09
+
+### Changed
+- Performance improvement in ST_ASQUADINT_POLYFILL.
+
 ## [1.0.3] - 2021-08-11
 
 ### Fixed

--- a/modules/quadkey/bigquery/doc/VERSION.md
+++ b/modules/quadkey/bigquery/doc/VERSION.md
@@ -18,5 +18,5 @@ Returns the current version of the quadkey module.
 
 ```sql
 SELECT carto-os.quadkey.VERSION();
--- 1.0.3
+-- 1.0.4
 ```

--- a/modules/quadkey/bigquery/lib/quadkey.js
+++ b/modules/quadkey/bigquery/lib/quadkey.js
@@ -308,7 +308,7 @@ export function kring_indexed (quadint, distance) {
  * @return {array}          array of quadints containing a geography
  */
 export function geojsonToQuadints (poly, limits) {
-    return tilecover.indexes(poly, limits).map(quadintFromQuadkey);
+    return tilecover.tiles(poly, limits).map(tile => quadintFromZXY(tile[2], tile[0], tile[1]));
 }
 
 const clipNumber = (num, a, b) => Math.max(Math.min(num, Math.max(a, b)), Math.min(a, b));

--- a/modules/quadkey/bigquery/package.json
+++ b/modules/quadkey/bigquery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadkey_bigquery",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Quadkey module for BigQuery",
   "author": "CARTO",
   "license": "BSD-3-Clause",

--- a/modules/quadkey/snowflake/CHANGELOG.md
+++ b/modules/quadkey/snowflake/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2021-09-09
+
+### Changed
+- Performance improvement in ST_ASQUADINT_POLYFILL.
+
 ## [1.0.1] - 2021-08-11
 
 ### Fixed

--- a/modules/quadkey/snowflake/doc/VERSION.md
+++ b/modules/quadkey/snowflake/doc/VERSION.md
@@ -16,5 +16,5 @@ Returns the current version of the quadkey module.
 
 ```sql
 SELECT sfcarto.quadkey.VERSION();
--- 1.0.1
+-- 1.0.2
 ```

--- a/modules/quadkey/snowflake/lib/quadkey.js
+++ b/modules/quadkey/snowflake/lib/quadkey.js
@@ -225,7 +225,7 @@ export function kring (quadint, distance) {
  * @return {array}          array of quadints containing a geography
  */
 export function geojsonToQuadints (poly, limits) {
-    return tilecover.indexes(poly, limits).map(quadintFromQuadkey);
+    return tilecover.tiles(poly, limits).map(tile => quadintFromZXY(tile[2], tile[0], tile[1]));
 }
 
 const clipNumber = (num, a, b) => Math.max(Math.min(num, Math.max(a, b)), Math.min(a, b));

--- a/modules/quadkey/snowflake/package.json
+++ b/modules/quadkey/snowflake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadkey_snowflake",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Quadkey module for Snowflake",
   "author": "CARTO",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Depending on the resolution and execution this has more or less impact but in general there was some performance improvement.
For instance, running:
```
select bqcarto.quadkey.ST_ASQUADINT_POLYFILL(ST_GEOGFROMGEOJSON('{ "type": "MultiPolygon", "coordinates": [ [ [ [-176.484375, 84.7383871209534], [-176.484375, 84.7060489350415], [-176.1328125, 84.7060489350415], [-176.1328125, 84.7383871209534], [-176.484375, 84.7383871209534] ] ], [ [ [-175.78125, 84.7383871209534], [-175.78125, 84.7060489350415], [-175.4296875, 84.7060489350415], [-175.4296875, 84.7383871209534], [-175.78125, 84.7383871209534] ] ] ] } '),18);
```

Before:
<img width="935" alt="Screenshot-before" src="https://user-images.githubusercontent.com/6054336/132678825-befb0610-4f29-4ca7-8178-946d95c8fc36.png">

After:
<img width="908" alt="Screenshot-after" src="https://user-images.githubusercontent.com/6054336/132678814-7054172a-ef26-4f80-b5ff-aa8b58c98d11.png">