### PR TITLE
fix setool parameters

### DIFF
--- a/common/redshift/Makefile
+++ b/common/redshift/Makefile
@@ -88,7 +88,7 @@ clean-deploy: check
 	$(MAKE) share-remove
 	$(MAKE) schema-remove || ((sleep 5 && $(MAKE) schema-remove) || exit 1)
 
-storage-upload: build venv3
+storage-upload: build venv2 venv3
 	for f in $(wildcard dist/*.zip); do \
 		$(AWS) s3 cp $$f $(AWS_S3_BUCKET) || exit 1; \
 	done

--- a/common/redshift/Makefile
+++ b/common/redshift/Makefile
@@ -88,7 +88,7 @@ clean-deploy: check
 	$(MAKE) share-remove
 	$(MAKE) schema-remove || ((sleep 5 && $(MAKE) schema-remove) || exit 1)
 
-storage-upload: build venv2 venv3
+storage-upload: build venv2
 	for f in $(wildcard dist/*.zip); do \
 		$(AWS) s3 cp $$f $(AWS_S3_BUCKET) || exit 1; \
 	done


### PR DESCRIPTION
The parameters where being concatenated wrongly for all the warehouses example:
INPUT:
```
param1,param2
INT,FLOAT
```

Was producing something like:
`param1 param2, INT FLOAT`

Instead of:
`param1 INT, param2 FLOAT`