### PR TITLE
Boundary issue with quadint 0

### DIFF
--- a/modules/quadkey/bigquery/CHANGELOG.md
+++ b/modules/quadkey/bigquery/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2021-10-01
+
+### fixed
+- Fix ST_BOUNDARY for level 1 and 2.
+
 ## [1.0.5] - 2021-09-22
 
 ### Changed

--- a/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
+++ b/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
@@ -7,100 +7,19 @@ RETURNS GEOGRAPHY
 AS (
     CASE
     -- Deal with level 0 boundary issue.
-      WHEN quadint=0 THEN ST_GeogFromText('FULLGLOBE')
+      WHEN quadint=0 THEN
+            ST_GEOGFROMGEOJSON('{"coordinates":[[[-180,85.0511287798066],[-180,-85.0511287798066],[180,-85.0511287798066],[180,85.0511287798066],[-180,85.0511287798066]]],"type":"Polygon"}')
     -- Deal with level 1. Prevent error from antipodal vertices.
       WHEN quadint=1 THEN
-            ST_MAKEPOLYGON(
-                ST_MAKELINE([
-                    ST_GEOGPOINT(
-                        0,
-                        0),
-                    ST_GEOGPOINT(
-                        0,
-                        (360/acos(-1)*atan(pow(exp(1),acos(-1))))-90),
-                    ST_GEOGPOINT(
-                        -180,
-                        (360/acos(-1)*atan(pow(exp(1),acos(-1))))-90),
-                    ST_GEOGPOINT(
-                        -180,
-                        0,
-                    ST_GEOGPOINT(
-                        -90,
-                        0),
-                    ST_GEOGPOINT(
-                        0,
-                        0)
-                    ])
-                )
+            ST_GEOGFROMTEXT ("POLYGON((0 0, 0 85.0511287798066, -180 85.0511287798066, -180 0, -90 0, 0 0))")
       WHEN quadint=33 THEN
-            ST_MAKEPOLYGON(
-                ST_MAKELINE([
-                    ST_GEOGPOINT(
-                        180,
-                        0),
-                    ST_GEOGPOINT(
-                        180,
-                        (360/acos(-1)*atan(pow(exp(1),acos(-1))))-90),
-                    ST_GEOGPOINT(
-                        0,
-                        (360/acos(-1)*atan(pow(exp(1),acos(-1))))-90),
-                    ST_GEOGPOINT(
-                        0,
-                        0),
-                    ST_GEOGPOINT(
-                        90,
-                        0),
-                    ST_GEOGPOINT(
-                        180,
-                        0)
-                    ])
-                )
+            ST_GEOGFROMTEXT ("POLYGON((180 0, 180 85.0511287798066, 0 85.0511287798066, 0 0, 90 0, 180 0))")
       WHEN quadint=65 THEN
-            ST_MAKEPOLYGON(
-                ST_MAKELINE([
-                    ST_GEOGPOINT(
-                        0,
-                        0),
-                    ST_GEOGPOINT(
-                        -90,
-                        0,
-                    ST_GEOGPOINT(
-                        -180,
-                        0),
-                    ST_GEOGPOINT(
-                        -180,
-                        90-(360/acos(-1)*atan(pow(exp(1),acos(-1))))),
-                    ST_GEOGPOINT(
-                        0,
-                        90-(360/acos(-1)*atan(pow(exp(1),acos(-1))))),
-                    ST_GEOGPOINT(
-                        180,
-                        0)
-                    ])
-                )
+            ST_GEOGFROMTEXT ("POLYGON((0 0, -90 0, 180 0, -180 -85.0511287798066, 0 -85.0511287798066, 0 0))")
+
       WHEN quadint=97 THEN
-            ST_MAKEPOLYGON(
-                ST_MAKELINE([
-                    ST_GEOGPOINT(
-                        180,
-                        0),
-                    ST_GEOGPOINT(
-                        90,
-                        0,
-                    ST_GEOGPOINT(
-                        0,
-                        0),
-                    ST_GEOGPOINT(
-                        0,
-                        90-(360/acos(-1)*atan(pow(exp(1),acos(-1))))),
-                    ST_GEOGPOINT(
-                        180,
-                        90-(360/acos(-1)*atan(pow(exp(1),acos(-1))))),
-                    ST_GEOGPOINT(
-                        180,
-                        0)
-                    ])
-                )
+            ST_GEOGFROMTEXT ("POLYGON((180 0, 90 0, 0 0, 0 -85.0511287798066, 180 -85.0511287798066, 180 0))")
+
       ELSE COALESCE(
             ST_MAKEPOLYGON(
                 ST_MAKELINE([

--- a/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
+++ b/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
@@ -9,12 +9,100 @@ AS (
     -- Deal with level 0 boundary issue.
       WHEN quadint=0 THEN ST_GeogFromText('FULLGLOBE')
     -- Deal with level 1. Prevent error from antipodal vertices.
-      WHEN quadint=1 THEN ST_GeogFromText('POLYGON((0 0,0 90,-180 90,-180 0,-90 0,0 0))')
-      WHEN quadint=33 THEN ST_GeogFromText('POLYGON((180 0,180 90,0 90,0 0,90 0,180 0))')
-      WHEN quadint=65 THEN ST_GeogFromText('POLYGON((0 0,-90 0,-180 0,-180 -90,0 -90,0 0))')
-      WHEN quadint=97 THEN ST_GeogFromText('POLYGON((180 0,90 0,0 0,0 -90,180 -90,180 0))')
+      WHEN quadint=1 THEN
+            ST_MAKEPOLYGON(
+                ST_MAKELINE([
+                    ST_GEOGPOINT(
+                        0,
+                        0),
+                    ST_GEOGPOINT(
+                        0,
+                        (360/acos(-1)*atan(pow(exp(1),acos(-1))))-90),
+                    ST_GEOGPOINT(
+                        -180,
+                        (360/acos(-1)*atan(pow(exp(1),acos(-1))))-90),
+                    ST_GEOGPOINT(
+                        -180,
+                        0,
+                    ST_GEOGPOINT(
+                        -90,
+                        0),
+                    ST_GEOGPOINT(
+                        0,
+                        0)
+                    ])
+                )
+      WHEN quadint=33 THEN
+            ST_MAKEPOLYGON(
+                ST_MAKELINE([
+                    ST_GEOGPOINT(
+                        180,
+                        0),
+                    ST_GEOGPOINT(
+                        180,
+                        (360/acos(-1)*atan(pow(exp(1),acos(-1))))-90),
+                    ST_GEOGPOINT(
+                        0,
+                        (360/acos(-1)*atan(pow(exp(1),acos(-1))))-90),
+                    ST_GEOGPOINT(
+                        0,
+                        0),
+                    ST_GEOGPOINT(
+                        90,
+                        0),
+                    ST_GEOGPOINT(
+                        180,
+                        0)
+                    ])
+                )
+      WHEN quadint=65 THEN
+            ST_MAKEPOLYGON(
+                ST_MAKELINE([
+                    ST_GEOGPOINT(
+                        0,
+                        0),
+                    ST_GEOGPOINT(
+                        -90,
+                        0,
+                    ST_GEOGPOINT(
+                        -180,
+                        0),
+                    ST_GEOGPOINT(
+                        -180,
+                        90-(360/acos(-1)*atan(pow(exp(1),acos(-1))))),
+                    ST_GEOGPOINT(
+                        0,
+                        90-(360/acos(-1)*atan(pow(exp(1),acos(-1))))),
+                    ST_GEOGPOINT(
+                        180,
+                        0)
+                    ])
+                )
+      WHEN quadint=97 THEN
+            ST_MAKEPOLYGON(
+                ST_MAKELINE([
+                    ST_GEOGPOINT(
+                        180,
+                        0),
+                    ST_GEOGPOINT(
+                        90,
+                        0,
+                    ST_GEOGPOINT(
+                        0,
+                        0),
+                    ST_GEOGPOINT(
+                        0,
+                        90-(360/acos(-1)*atan(pow(exp(1),acos(-1))))),
+                    ST_GEOGPOINT(
+                        180,
+                        90-(360/acos(-1)*atan(pow(exp(1),acos(-1))))),
+                    ST_GEOGPOINT(
+                        180,
+                        0)
+                    ])
+                )
       ELSE COALESCE(
-            SAFE.ST_MAKEPOLYGON(
+            ST_MAKEPOLYGON(
                 ST_MAKELINE([
                     ST_GEOGPOINT(
                         `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
@@ -33,7 +121,7 @@ AS (
                         `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint))
                     ])
                 ),
-            NULL
+            ERROR('NULL argument passed to UDF')
         )
     END
 );

--- a/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
+++ b/modules/quadkey/bigquery/sql/ST_BOUNDARY.sql
@@ -5,26 +5,35 @@
 CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@quadkey.ST_BOUNDARY`(quadint INT64)
 RETURNS GEOGRAPHY
 AS (
-    COALESCE(
-        ST_MAKEPOLYGON(
-            ST_MAKELINE([
-                ST_GEOGPOINT(
-                    `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
-                    `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint)),
-                ST_GEOGPOINT(
-                    `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
-                    `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint)),
-                ST_GEOGPOINT(
-                    `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
-                    `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint)),
-                ST_GEOGPOINT(
-                    `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
-                    `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint)),
-                ST_GEOGPOINT(
-                    `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
-                    `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint))
-                ])
-            ),
-        ERROR('NULL argument passed to UDF')
-    )
+    CASE
+    -- Deal with level 0 boundary issue.
+      WHEN quadint=0 THEN ST_GeogFromText('FULLGLOBE')
+    -- Deal with level 1. Prevent error from antipodal vertices.
+      WHEN quadint=1 THEN ST_GeogFromText('POLYGON((0 0,0 90,-180 90,-180 0,-90 0,0 0))')
+      WHEN quadint=33 THEN ST_GeogFromText('POLYGON((180 0,180 90,0 90,0 0,90 0,180 0))')
+      WHEN quadint=65 THEN ST_GeogFromText('POLYGON((0 0,-90 0,-180 0,-180 -90,0 -90,0 0))')
+      WHEN quadint=97 THEN ST_GeogFromText('POLYGON((180 0,90 0,0 0,0 -90,180 -90,180 0))')
+      ELSE COALESCE(
+            SAFE.ST_MAKEPOLYGON(
+                ST_MAKELINE([
+                    ST_GEOGPOINT(
+                        `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
+                        `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint)),
+                    ST_GEOGPOINT(
+                        `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
+                        `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint)),
+                    ST_GEOGPOINT(
+                        `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
+                        `@@BQ_PREFIX@@quadkey.__BBOX_S`(quadint)),
+                    ST_GEOGPOINT(
+                        `@@BQ_PREFIX@@quadkey.__BBOX_W`(quadint),
+                        `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint)),
+                    ST_GEOGPOINT(
+                        `@@BQ_PREFIX@@quadkey.__BBOX_E`(quadint),
+                        `@@BQ_PREFIX@@quadkey.__BBOX_N`(quadint))
+                    ])
+                ),
+            NULL
+        )
+    END
 );

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -3,7 +3,7 @@ const { runQuery } = require('../../../../../common/bigquery/test-utils');
 test('ST_BOUNDARY should work', async () => {
     const query = `
     SELECT
-      ST_BOUNDARY_(quadint) boundary,
+      \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(quadint) boundary,
       quadint
     FROM
       UNNEST([0,1,2,33,34,65,97,130,258,386,12070922,791040491538,12960460429066265]) quadint

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -12,12 +12,12 @@ test('ST_BOUNDARY should work', async () => {
     
     const rows = await runQuery(query);
     expect(rows.length).toEqual(13);
-    expect(JSON.stringify(rows[1].boundary.value)).toEqual('"POLYGON((0 0, -180 90, -180 0, -90 0, 0 0))"');
+    expect(JSON.stringify(rows[1].boundary.value)).toEqual('"POLYGON((0 0, 0 85.0511287798066, -180 85.0511287798066, -180 0, -90 0, 0 0))"');
     expect(JSON.stringify(rows[2].boundary.value)).toEqual('"POLYGON((-180 85.0511287798066, -180 66.5132604431119, -90 66.5132604431119, -90 85.0511287798066, -180 85.0511287798066))"');
-    expect(JSON.stringify(rows[3].boundary.value)).toEqual('"POLYGON((180 0, 180 90, 0 0, 90 0, 180 0))"');
+    expect(JSON.stringify(rows[3].boundary.value)).toEqual('"POLYGON((180 0, 180 85.0511287798066, 0 85.0511287798066, 0 0, 90 0, 180 0))"');
     expect(JSON.stringify(rows[4].boundary.value)).toEqual('"POLYGON((-90 85.0511287798066, -90 66.5132604431119, 0 66.5132604431119, 0 85.0511287798066, -90 85.0511287798066))"');
-    expect(JSON.stringify(rows[5].boundary.value)).toEqual('"POLYGON((0 0, -90 0, -180 0, -180 -90, 0 0))"');
-    expect(JSON.stringify(rows[6].boundary.value)).toEqual('"POLYGON((180 0, 90 0, 0 0, 180 -90, 180 0))"');
+    expect(JSON.stringify(rows[5].boundary.value)).toEqual('"POLYGON((0 0, -90 0, 180 0, -180 -85.0511287798066, 0 -85.0511287798066, 0 0))"');
+    expect(JSON.stringify(rows[6].boundary.value)).toEqual('"POLYGON((180 0, 90 0, 0 0, 0 -85.0511287798066, 180 -85.0511287798066, 180 0))"');
     expect(JSON.stringify(rows[7].boundary.value)).toEqual('"POLYGON((-180 66.5132604431119, -180 0, -90 0, -90 66.5132604431119, -180 66.5132604431119))"');
     expect(JSON.stringify(rows[8].boundary.value)).toEqual('"POLYGON((-180 0, -180 -66.5132604431119, -90 -66.5132604431119, -90 0, -180 0))"');
     expect(JSON.stringify(rows[9].boundary.value)).toEqual('"POLYGON((-180 -66.5132604431119, -180 -85.0511287798066, -90 -85.0511287798066, -90 -66.5132604431119, -180 -66.5132604431119))"');

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -15,16 +15,16 @@ test('ST_BOUNDARY should work', async () => {
     expect(JSON.stringify(rows[0].boundary.value)).toEqual('"GEOMETRYCOLLECTION(POLYGON((0 0, 120 0, -120 0, 0 0)), POLYGON((0 0, -120 0, 120 0, 0 0)))"');
     expect(JSON.stringify(rows[1].boundary.value)).toEqual('"POLYGON((0 0, -180 90, -180 0, -90 0, 0 0))"');
     expect(JSON.stringify(rows[2].boundary.value)).toEqual('"POLYGON((-180 85.0511287798066, -180 66.5132604431119, -90 66.5132604431119, -90 85.0511287798066, -180 85.0511287798066))"');
-    expect(JSON.stringify(rows[3].boundary.value)).toEqual('POLYGON((180 0, 180 90, 0 0, 90 0, 180 0))');
-    expect(JSON.stringify(rows[4].boundary.value)).toEqual('POLYGON((-90 85.0511287798066, -90 66.5132604431119, 0 66.5132604431119, 0 85.0511287798066, -90 85.0511287798066))');
-    expect(JSON.stringify(rows[5].boundary.value)).toEqual('POLYGON((0 0, -90 0, -180 0, -180 -90, 0 0))');
-    expect(JSON.stringify(rows[6].boundary.value)).toEqual('POLYGON((180 0, 90 0, 0 0, 180 -90, 180 0))');
-    expect(JSON.stringify(rows[7].boundary.value)).toEqual('POLYGON((-180 66.5132604431119, -180 0, -90 0, -90 66.5132604431119, -180 66.5132604431119))');
-    expect(JSON.stringify(rows[8].boundary.value)).toEqual('POLYGON((-180 0, -180 -66.5132604431119, -90 -66.5132604431119, -90 0, -180 0))');
-    expect(JSON.stringify(rows[9].boundary.value)).toEqual('POLYGON((-180 -66.5132604431119, -180 -85.0511287798066, -90 -85.0511287798066, -90 -66.5132604431119, -180 -66.5132604431119))');
-    expect(JSON.stringify(rows[10].boundary.value)).toEqual('POLYGON((-45 45.089035564831, -45 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -45 45.089035564831))');
-    expect(JSON.stringify(rows[11].boundary.value)).toEqual('POLYGON((-45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813, -44.9986267089844 45.0007380782907, -45 45.0007380782907))');
-    expect(JSON.stringify(rows[12].boundary.value)).toEqual('POLYGON((-45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367, -44.9999892711639 45.0000021990696, -45 45.0000021990696))');
+    expect(JSON.stringify(rows[3].boundary.value)).toEqual('"POLYGON((180 0, 180 90, 0 0, 90 0, 180 0))"');
+    expect(JSON.stringify(rows[4].boundary.value)).toEqual('"POLYGON((-90 85.0511287798066, -90 66.5132604431119, 0 66.5132604431119, 0 85.0511287798066, -90 85.0511287798066))"');
+    expect(JSON.stringify(rows[5].boundary.value)).toEqual('"POLYGON((0 0, -90 0, -180 0, -180 -90, 0 0))"');
+    expect(JSON.stringify(rows[6].boundary.value)).toEqual('"POLYGON((180 0, 90 0, 0 0, 180 -90, 180 0))"');
+    expect(JSON.stringify(rows[7].boundary.value)).toEqual('"POLYGON((-180 66.5132604431119, -180 0, -90 0, -90 66.5132604431119, -180 66.5132604431119))"');
+    expect(JSON.stringify(rows[8].boundary.value)).toEqual('"POLYGON((-180 0, -180 -66.5132604431119, -90 -66.5132604431119, -90 0, -180 0))"');
+    expect(JSON.stringify(rows[9].boundary.value)).toEqual('"POLYGON((-180 -66.5132604431119, -180 -85.0511287798066, -90 -85.0511287798066, -90 -66.5132604431119, -180 -66.5132604431119))"');
+    expect(JSON.stringify(rows[10].boundary.value)).toEqual('"POLYGON((-45 45.089035564831, -45 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -45 45.089035564831))"');
+    expect(JSON.stringify(rows[11].boundary.value)).toEqual('"POLYGON((-45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813, -44.9986267089844 45.0007380782907, -45 45.0007380782907))"');
+    expect(JSON.stringify(rows[12].boundary.value)).toEqual('"POLYGON((-45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367, -44.9999892711639 45.0000021990696, -45 45.0000021990696))"');
 });
 
 test('ST_BOUNDARY should fail with NULL argument', async () => {

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -5,7 +5,7 @@ test('ST_BOUNDARY should work', async () => {
         SELECT
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12070922) as geog1,
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(791040491538) as geog2,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12960460429066265) as geog3`;
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12960460429066265) as geog3,
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(0) as geog4,
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(1) as geog5,
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(33) as geog6,

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -12,7 +12,6 @@ test('ST_BOUNDARY should work', async () => {
     
     const rows = await runQuery(query);
     expect(rows.length).toEqual(13);
-    expect(JSON.stringify(rows[0].boundary.value)).toEqual('"GEOMETRYCOLLECTION(POLYGON((0 0, 120 0, -120 0, 0 0)), POLYGON((0 0, -120 0, 120 0, 0 0)))"');
     expect(JSON.stringify(rows[1].boundary.value)).toEqual('"POLYGON((0 0, -180 90, -180 0, -90 0, 0 0))"');
     expect(JSON.stringify(rows[2].boundary.value)).toEqual('"POLYGON((-180 85.0511287798066, -180 66.5132604431119, -90 66.5132604431119, -90 85.0511287798066, -180 85.0511287798066))"');
     expect(JSON.stringify(rows[3].boundary.value)).toEqual('"POLYGON((180 0, 180 90, 0 0, 90 0, 180 0))"');

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -2,36 +2,29 @@ const { runQuery } = require('../../../../../common/bigquery/test-utils');
 
 test('ST_BOUNDARY should work', async () => {
     const query = `
-        SELECT
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12070922) as geog1,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(791040491538) as geog2,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12960460429066265) as geog3,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(0) as geog4,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(1) as geog5,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(33) as geog6,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(65) as geog7,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(97) as geog8,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(2) as geog9,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(130) as geog10,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(258) as geog11,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(386) as geog12,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(34) as geog13`;
+    SELECT
+      ST_BOUNDARY_(quadint) boundary,
+      quadint
+    FROM
+      UNNEST([0,1,2,33,34,65,97,130,258,386,12070922,791040491538,12960460429066265]) quadint
+    ORDER BY
+      quadint`;
     
     const rows = await runQuery(query);
-    expect(rows.length).toEqual(1);
-    expect(JSON.stringify(rows[0].geog1.value)).toEqual('"POLYGON((-45 45.089035564831, -45 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -45 45.089035564831))"');
-    expect(JSON.stringify(rows[0].geog2.value)).toEqual('"POLYGON((-45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813, -44.9986267089844 45.0007380782907, -45 45.0007380782907))"');
-    expect(JSON.stringify(rows[0].geog3.value)).toEqual('"POLYGON((-45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367, -44.9999892711639 45.0000021990696, -45 45.0000021990696))"');
-    expect(JSON.stringify(rows[0].geog4.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog5.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog6.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog7.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog8.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog9.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog10.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog11.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog12.value)).toEqual('');
-    expect(JSON.stringify(rows[0].geog13.value)).toEqual('');
+    expect(rows.length).toEqual(13);
+    expect(JSON.stringify(rows[0].boundary.value)).toEqual('"GEOMETRYCOLLECTION(POLYGON((0 0, 120 0, -120 0, 0 0)), POLYGON((0 0, -120 0, 120 0, 0 0)))"');
+    expect(JSON.stringify(rows[1].boundary.value)).toEqual('"POLYGON((0 0, -180 90, -180 0, -90 0, 0 0))"');
+    expect(JSON.stringify(rows[2].boundary.value)).toEqual('"POLYGON((-180 85.0511287798066, -180 66.5132604431119, -90 66.5132604431119, -90 85.0511287798066, -180 85.0511287798066))"');
+    expect(JSON.stringify(rows[3].boundary.value)).toEqual('POLYGON((180 0, 180 90, 0 0, 90 0, 180 0))');
+    expect(JSON.stringify(rows[4].boundary.value)).toEqual('POLYGON((-90 85.0511287798066, -90 66.5132604431119, 0 66.5132604431119, 0 85.0511287798066, -90 85.0511287798066))');
+    expect(JSON.stringify(rows[5].boundary.value)).toEqual('POLYGON((0 0, -90 0, -180 0, -180 -90, 0 0))');
+    expect(JSON.stringify(rows[6].boundary.value)).toEqual('POLYGON((180 0, 90 0, 0 0, 180 -90, 180 0))');
+    expect(JSON.stringify(rows[7].boundary.value)).toEqual('POLYGON((-180 66.5132604431119, -180 0, -90 0, -90 66.5132604431119, -180 66.5132604431119))');
+    expect(JSON.stringify(rows[8].boundary.value)).toEqual('POLYGON((-180 0, -180 -66.5132604431119, -90 -66.5132604431119, -90 0, -180 0))');
+    expect(JSON.stringify(rows[9].boundary.value)).toEqual('POLYGON((-180 -66.5132604431119, -180 -85.0511287798066, -90 -85.0511287798066, -90 -66.5132604431119, -180 -66.5132604431119))');
+    expect(JSON.stringify(rows[10].boundary.value)).toEqual('POLYGON((-45 45.089035564831, -45 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -45 45.089035564831))');
+    expect(JSON.stringify(rows[11].boundary.value)).toEqual('POLYGON((-45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813, -44.9986267089844 45.0007380782907, -45 45.0007380782907))');
+    expect(JSON.stringify(rows[12].boundary.value)).toEqual('POLYGON((-45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367, -44.9999892711639 45.0000021990696, -45 45.0000021990696))');
 });
 
 test('ST_BOUNDARY should fail with NULL argument', async () => {

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -5,22 +5,23 @@ test('ST_BOUNDARY should work', async () => {
         SELECT
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12070922) as geog1,
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(791040491538) as geog2,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(0) as geog3,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(1) as geog4,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(33) as geog5,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(65) as geog6,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(97) as geog7,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(2) as geog8,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(130) as geog9,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(258) as geog10,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(386) as geog11,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(34) as geog12;
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12960460429066265) as geog3`;
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(0) as geog4,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(1) as geog5,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(33) as geog6,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(65) as geog7,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(97) as geog8,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(2) as geog9,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(130) as geog10,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(258) as geog11,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(386) as geog12,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(34) as geog13`;
     
     const rows = await runQuery(query);
     expect(rows.length).toEqual(1);
     expect(JSON.stringify(rows[0].geog1.value)).toEqual('"POLYGON((-45 45.089035564831, -45 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -45 45.089035564831))"');
     expect(JSON.stringify(rows[0].geog2.value)).toEqual('"POLYGON((-45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813, -44.9986267089844 45.0007380782907, -45 45.0007380782907))"');
-    expect(JSON.stringify(rows[0].geog3.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog3.value)).toEqual('"POLYGON((-45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367, -44.9999892711639 45.0000021990696, -45 45.0000021990696))"');
     expect(JSON.stringify(rows[0].geog4.value)).toEqual('');
     expect(JSON.stringify(rows[0].geog5.value)).toEqual('');
     expect(JSON.stringify(rows[0].geog6.value)).toEqual('');
@@ -30,6 +31,7 @@ test('ST_BOUNDARY should work', async () => {
     expect(JSON.stringify(rows[0].geog10.value)).toEqual('');
     expect(JSON.stringify(rows[0].geog11.value)).toEqual('');
     expect(JSON.stringify(rows[0].geog12.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog13.value)).toEqual('');
 });
 
 test('ST_BOUNDARY should fail with NULL argument', async () => {

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -5,13 +5,31 @@ test('ST_BOUNDARY should work', async () => {
         SELECT
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12070922) as geog1,
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(791040491538) as geog2,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12960460429066265) as geog3`;
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(0) as geog3`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(1) as geog4`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(33) as geog5`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(65) as geog6`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(97) as geog7`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(2) as geog8`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(130) as geog9`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(258) as geog10`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(386) as geog11`,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(34) as geog12`;
     
     const rows = await runQuery(query);
     expect(rows.length).toEqual(1);
     expect(JSON.stringify(rows[0].geog1.value)).toEqual('"POLYGON((-45 45.089035564831, -45 44.840290651398, -44.6484375 44.840290651398, -44.6484375 45.089035564831, -45 45.089035564831))"');
     expect(JSON.stringify(rows[0].geog2.value)).toEqual('"POLYGON((-45 45.0007380782907, -45 44.9997670191813, -44.9986267089844 44.9997670191813, -44.9986267089844 45.0007380782907, -45 45.0007380782907))"');
-    expect(JSON.stringify(rows[0].geog3.value)).toEqual('"POLYGON((-45 45.0000021990696, -45 44.9999946126367, -44.9999892711639 44.9999946126367, -44.9999892711639 45.0000021990696, -45 45.0000021990696))"'); 
+    expect(JSON.stringify(rows[0].geog3.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog4.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog5.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog6.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog7.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog8.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog9.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog10.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog11.value)).toEqual('');
+    expect(JSON.stringify(rows[0].geog12.value)).toEqual('');
 });
 
 test('ST_BOUNDARY should fail with NULL argument', async () => {

--- a/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/bigquery/test/integration/ST_BOUNDARY.test.js
@@ -5,16 +5,16 @@ test('ST_BOUNDARY should work', async () => {
         SELECT
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(12070922) as geog1,
             \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(791040491538) as geog2,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(0) as geog3`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(1) as geog4`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(33) as geog5`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(65) as geog6`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(97) as geog7`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(2) as geog8`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(130) as geog9`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(258) as geog10`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(386) as geog11`,
-            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(34) as geog12`;
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(0) as geog3,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(1) as geog4,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(33) as geog5,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(65) as geog6,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(97) as geog7,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(2) as geog8,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(130) as geog9,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(258) as geog10,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(386) as geog11,
+            \`@@BQ_PREFIX@@quadkey.ST_BOUNDARY\`(34) as geog12;
     
     const rows = await runQuery(query);
     expect(rows.length).toEqual(1);

--- a/modules/quadkey/snowflake/test/integration/ST_BOUNDARY.test.js
+++ b/modules/quadkey/snowflake/test/integration/ST_BOUNDARY.test.js
@@ -3,15 +3,21 @@ const { runQuery } = require('../../../../../common/snowflake/test-utils');
 test('ST_BOUNDARY should work', async () => {
     const query = `
         SELECT
-            @@SF_PREFIX@@quadkey.ST_BOUNDARY(12070922) as geog1,
-            @@SF_PREFIX@@quadkey.ST_BOUNDARY(791040491538) as geog2,
-            @@SF_PREFIX@@quadkey.ST_BOUNDARY(12960460429066265) as geog3`;
+            @@SF_PREFIX@@quadkey.ST_BOUNDARY(0) as geog1,
+            @@SF_PREFIX@@quadkey.ST_BOUNDARY(1) as geog2,
+            @@SF_PREFIX@@quadkey.ST_BOUNDARY(2) as geog3,
+            @@SF_PREFIX@@quadkey.ST_BOUNDARY(12070922) as geog4,
+            @@SF_PREFIX@@quadkey.ST_BOUNDARY(791040491538) as geog5,
+            @@SF_PREFIX@@quadkey.ST_BOUNDARY(12960460429066265) as geog6`;
     
     const rows = await runQuery(query);
-    expect(rows.length).toEqual(1);  
-    expect(JSON.stringify(rows[0]['GEOG1'])).toEqual('{"coordinates":[[[-45,45.08903556483103],[-45,44.840290651397986],[-44.6484375,44.840290651397986],[-44.6484375,45.08903556483103],[-45,45.08903556483103]]],"type":"Polygon"}');
-    expect(JSON.stringify(rows[0]['GEOG2'])).toEqual('{"coordinates":[[[-45,45.00073807829068],[-45,44.99976701918129],[-44.998626708984375,44.99976701918129],[-44.998626708984375,45.00073807829068],[-45,45.00073807829068]]],"type":"Polygon"}');
-    expect(JSON.stringify(rows[0]['GEOG3'])).toEqual('{"coordinates":[[[-45,45.00000219906962],[-45,44.999994612636684],[-44.99998927116394,44.999994612636684],[-44.99998927116394,45.00000219906962],[-45,45.00000219906962]]],"type":"Polygon"}'); 
+    expect(rows.length).toEqual(1);
+    expect(JSON.stringify(rows[0]['GEOG1'])).toEqual('{"coordinates":[[[-180,85.0511287798066],[-180,-85.0511287798066],[180,-85.0511287798066],[180,85.0511287798066],[-180,85.0511287798066]]],"type":"Polygon"}');
+    expect(JSON.stringify(rows[0]['GEOG2'])).toEqual('{"coordinates":[[[-180,85.0511287798066],[-180,0],[0,0],[0,85.0511287798066],[-180,85.0511287798066]]],"type":"Polygon"}');
+    expect(JSON.stringify(rows[0]['GEOG3'])).toEqual('{"coordinates":[[[-180,85.0511287798066],[-180,66.51326044311186],[-90,66.51326044311186],[-90,85.0511287798066],[-180,85.0511287798066]]],"type":"Polygon"}');
+    expect(JSON.stringify(rows[0]['GEOG4'])).toEqual('{"coordinates":[[[-45,45.08903556483103],[-45,44.840290651397986],[-44.6484375,44.840290651397986],[-44.6484375,45.08903556483103],[-45,45.08903556483103]]],"type":"Polygon"}');
+    expect(JSON.stringify(rows[0]['GEOG5'])).toEqual('{"coordinates":[[[-45,45.00073807829068],[-45,44.99976701918129],[-44.998626708984375,44.99976701918129],[-44.998626708984375,45.00073807829068],[-45,45.00073807829068]]],"type":"Polygon"}');
+    expect(JSON.stringify(rows[0]['GEOG6'])).toEqual('{"coordinates":[[[-45,45.00000219906962],[-45,44.999994612636684],[-44.99998927116394,44.999994612636684],[-44.99998927116394,45.00000219906962],[-45,45.00000219906962]]],"type":"Polygon"}');
 });
 
 test('ST_BOUNDARY should fail with NULL argument', async () => {


### PR DESCRIPTION
Fix the following function in BigQuery returns a Linestring:

```sql
SELECT bqcarto.quadkey.ST_BOUNDARY(0);
-- LINESTRING(-180 85.0511287798066, 180 0, -180 -85.0511287798066)
```

However, in Snowflake and Redshift it returns the proper Polygon:

```sql
SELECT ST_ASWKT(sfcarto.quadkey.ST_BOUNDARY(0));
-- POLYGON((-180 85.05112878,-180 -85.05112878,180 -85.05112878,180 85.05112878,-180 85.05112878))
```

