### PR TITLE
Remove h3 lib

### DIFF
--- a/modules/h3/snowflake/package.json
+++ b/modules/h3/snowflake/package.json
@@ -6,6 +6,5 @@
   "license": "BSD-3-Clause",
   "private": true,
   "dependencies": {
-    "h3-js": "3.7.2"
   }
 }

--- a/modules/h3/snowflake/yarn.lock
+++ b/modules/h3/snowflake/yarn.lock
@@ -2,7 +2,3 @@
 # yarn lockfile v1
 
 
-h3-js@3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-3.7.2.tgz#61d4feb7bb42868ca9cdb2d5cf9d9dda94f9e5a3"
-  integrity sha512-LPjlHSwB9zQZrMqKloCZmmmt3yZzIK7nqPcXqwU93zT3TtYG6jP4tZBzAPouxut7lLjdFbMQ75wRBiKfpsnY7w==


### PR DESCRIPTION
Try to fix this kind of problem:

```
error An unexpected error occurred: "ENOENT: no such file or directory, lstat '/home/runner/work/carto-advanced-spatial-extension/carto-advanced-spatial-extension/core/modules/h3/snowflake/node_modules/h3-js/doc-files/insert-version.js'".
make[4]: *** [../../../common/snowflake/Makefile:46: /home/runner/work/carto-advanced-spatial-extension/carto-advanced-spatial-extension/core/modules/h3/snowflake/node_modules] Error 1
make[4]: *** Waiting for unfinished jobs....
make[3]: *** [../../../common/snowflake/Makefile:97: deploy] Error 2
make[2]: *** [../../../common/snowflake/Makefile:89: deploy] Error 1
make[1]: *** [Makefile:11: deploy] Error 1
make: *** [Makefile:24: test-integration-full] Error 2
```