### PR TITLE
add QUADINT_RESOLUTION function

### DIFF
--- a/modules/quadkey/bigquery/doc/QUADINT_RESOLUTION.md
+++ b/modules/quadkey/bigquery/doc/QUADINT_RESOLUTION.md
@@ -1,0 +1,24 @@
+### QUADINT_RESOLUTION
+
+{{% bannerNote type="code" %}}
+carto.QUADINT_RESOLUTION(quadint)
+{{%/ bannerNote %}}
+
+**Description**
+
+Returns the resolution of the input quadint.
+
+* `quadint`: `INT64` quadint from which to get resolution.
+
+**Return type**
+
+`INT64`
+
+{{% customSelector %}}
+**Example**
+{{%/ customSelector %}}
+
+```sql
+SELECT `carto-os`.carto.QUADINT_RESOLUTION(4388);
+-- 4
+```

--- a/modules/quadkey/bigquery/lib/index.js
+++ b/modules/quadkey/bigquery/lib/index.js
@@ -12,7 +12,8 @@ import {
     quadintToGeoJSON,
     quadintFromZXY,
     geojsonToQuadints,
-    ZXYFromQuadint
+    ZXYFromQuadint,
+    getQuadintResolution
 } from '../../shared/javascript/quadkey';
 
 export default {
@@ -29,5 +30,6 @@ export default {
     quadintFromZXY,
     geojsonToQuadints,
     ZXYFromQuadint,
+    getQuadintResolution,
     version
 };

--- a/modules/quadkey/bigquery/sql/QUADINT_RESOLUTION.sql
+++ b/modules/quadkey/bigquery/sql/QUADINT_RESOLUTION.sql
@@ -1,0 +1,16 @@
+----------------------------
+-- Copyright (C) 2021 CARTO
+----------------------------
+
+CREATE OR REPLACE FUNCTION `@@BQ_PREFIX@@carto.QUADINT_RESOLUTION`
+(quadint INT64)
+RETURNS INT64
+DETERMINISTIC
+LANGUAGE js
+OPTIONS (library=["@@BQ_LIBRARY_BUCKET@@"])
+AS """
+    if (quadint == null) {
+        throw new Error('NULL argument passed to UDF');
+    }
+    return quadkeyLib.getQuadintResolution(quadint);
+""";

--- a/modules/quadkey/bigquery/test/integration/QUADINT_RESOLUTION.test.js
+++ b/modules/quadkey/bigquery/test/integration/QUADINT_RESOLUTION.test.js
@@ -1,0 +1,31 @@
+const { runQuery } = require('../../../../../common/bigquery/test-utils');
+
+test('QUADINT_RESOLUTION should work at any level of zoom', async () => {
+    const query = `WITH zoomContext AS (
+        WITH zoomValues AS (
+            SELECT zoom FROM UNNEST (GENERATE_ARRAY(1,29)) AS zoom
+        )
+        SELECT *
+        FROM
+            zoomValues,
+            UNNEST(GENERATE_ARRAY(-90,90,15)) lat,
+            UNNEST(GENERATE_ARRAY(-180,180,15)) long
+    )
+    SELECT *
+    FROM (
+        SELECT *,
+            zoom AS expectedResolution,
+            \`@@BQ_PREFIX@@carto.QUADINT_RESOLUTION\`(
+                \`@@BQ_PREFIX@@carto.QUADINT_FROMGEOGPOINT\`(ST_GEOGPOINT(long, lat), zoom)) AS resolution
+        FROM zoomContext
+    )
+    WHERE resolution != expectedResolution`;
+
+    const rows = await runQuery(query);
+    expect(rows.length).toEqual(0);
+});
+
+test('QUADINT_RESOLUTION should fail with NULL argument', async () => {
+    let query = 'SELECT `@@BQ_PREFIX@@carto.QUADINT_RESOLUTION`(NULL);';
+    await expect(runQuery(query)).rejects.toThrow();
+});

--- a/modules/quadkey/bigquery/test/unit/index.test.js
+++ b/modules/quadkey/bigquery/test/unit/index.test.js
@@ -13,5 +13,6 @@ test('quadkey library defined', () => {
     expect(quadkeyLib.quadintToGeoJSON).toBeDefined();
     expect(quadkeyLib.geojsonToQuadints).toBeDefined();
     expect(quadkeyLib.ZXYFromQuadint).toBeDefined();
+    expect(quadkeyLib.getQuadintResolution).toBeDefined();
     expect(quadkeyLib.version).toBe(version);
 });

--- a/modules/quadkey/bigquery/test/unit/quadkey.test.js
+++ b/modules/quadkey/bigquery/test/unit/quadkey.test.js
@@ -193,3 +193,31 @@ test('Should be able to encode/decode tiles at any level of zoom', async () => {
         }
     }
 });
+
+test('Should be able to get resolution of tiles at any level of zoom', async () => {
+    let tilesPerLevel, x, y;
+    for (let z = 0; z < 30; ++z) {
+        if (z === 0) {
+            tilesPerLevel = 1;
+        } else {
+            tilesPerLevel = 2 << (z - 1);
+        }
+
+        x = 0;
+        y = 0;
+        let resolution = lib.getQuadintResolution(lib.quadintFromZXY(z, x, y));
+        expect(resolution === z).toBeTruthy();
+
+        if (z > 0) {
+            x = tilesPerLevel / 2;
+            y = tilesPerLevel / 2;
+            resolution = lib.getQuadintResolution(lib.quadintFromZXY(z, x, y));
+            expect(resolution === z).toBeTruthy();
+
+            x = tilesPerLevel - 1;
+            y = tilesPerLevel - 1;
+            resolution = lib.getQuadintResolution(lib.quadintFromZXY(z, x, y));
+            expect(resolution === z).toBeTruthy();
+        }
+    }
+});

--- a/modules/quadkey/shared/javascript/quadkey.js
+++ b/modules/quadkey/shared/javascript/quadkey.js
@@ -307,4 +307,13 @@ export function geojsonToQuadints (poly, limits) {
     return tilecover.tiles(poly, limits).map(tile => quadintFromZXY(tile[2], tile[0], tile[1]));
 }
 
+/**
+ * get the resolution of a quadint
+ * @param  {int} quadint quadint to get the resolution of
+ * @return {int}         resolution of the input quadint
+ */
+ export function getQuadintResolution (quadint) {
+    return quadkeyFromQuadint(quadint).length;
+}
+
 const clipNumber = (num, a, b) => Math.max(Math.min(num, Math.max(a, b)), Math.min(a, b));


### PR DESCRIPTION
Similar to #208 , add a function to get the resolution of a quadint.

Under the hood this simply converts the quadint to a quadkey and gets its length. Pretty trivial but the average user probably wouldn't know how to do it on their own.