### PR TITLE
Allow multiple queries in redshift tests

### DIFF
--- a/common/redshift/test_utils/__init__.py
+++ b/common/redshift/test_utils/__init__.py
@@ -11,7 +11,25 @@ def run_query(query):
     )
     cursor = conn.cursor()
     cursor.execute(query.replace('@@RS_PREFIX@@', os.environ['RS_SCHEMA_PREFIX']))
-    return cursor.fetchall()
+    try:
+        return cursor.fetchall()
+    except:
+        return 'No results returned'
+
+def run_queries(queries):
+    conn = redshift_connector.connect(
+        host=os.environ['RS_HOST'],
+        database=os.environ['RS_DATABASE'],
+        user=os.environ['RS_USER'],
+        password=os.environ['RS_PASSWORD'],
+    )
+    cursor = conn.cursor()
+    for query in queries:
+        cursor.execute(query.replace('@@RS_PREFIX@@', os.environ['RS_SCHEMA_PREFIX']))
+    try:
+        return cursor.fetchall()
+    except:
+        return 'No results returned'
 
 def get_cursor():
     conn = redshift_connector.connect(


### PR DESCRIPTION
This change was done to allow create and drop tables in test.
As we are creating connections each time a query is created they are running in parallel and not in order.
Adding queries to run_queries will allow us to run queries in order.

I was considering ways to be able to run queries in order on each of the tests. And one would be to keep the connection in the test (even if it's created inside test_utils) and then pass it to run_query as parameter. But wanted to keep it similar to other warehouses.