### PR TITLE
Add utils for unit tests (which use python2)

### DIFF
--- a/common/redshift/test_unit_utils/__init__.py
+++ b/common/redshift/test_unit_utils/__init__.py
@@ -1,0 +1,8 @@
+from re import sub
+
+def norm_sql(sql):
+    sql = sub('\s+', ' ', sql)
+    sql = sub('\s?,\s?', ',', sql)
+    sql = sub('\( ', '(', sql)
+    sql = sub(' \)', ')', sql)
+    return sql.strip()


### PR DESCRIPTION
Add norm_sql function to aid in unit tests.
Note that unit tests uses venv2, so we can't use `test_utils` in those because it requires libraries only present in venv3.